### PR TITLE
Make member search more magic

### DIFF
--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -48,7 +48,7 @@ export default {
                 // yup. let's check if it's a barcode
                 if (/^92(?:00|1[1-3])00\d{7}$/.test(query)) {
                     // ACCESS card/app barcodes
-                    query = query.slice(-7);
+                    query = String(+query.slice(-7));
                 } else if (/^09\d{9}\d{2}\d{2}$/.test(query)) {
                     // SID library barcode: 09<SID><YY><CHK>
                     query = query.slice(2, 9+2);

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -46,7 +46,7 @@ export default {
             // is the search text numeric?
             if (/^\d+$/.test(query)) {
                 // yup. let's check if it's a barcode
-                if (/^92(?:00|1[1-3])00\d{7}$/.test(query)) {
+                if (/^9[12]0000\d{7}$/.test(query)) {
                     // ACCESS card/app barcodes
                     query = String(+query.slice(-7));
                 } else if (/^09\d{9}\d{2}\d{2}$/.test(query)) {

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -3,7 +3,7 @@ div
     form(@submit.prevent="autoselect")
         md-field.search-box
             label Search
-            md-input(v-model="search", autofocus)
+            md-input(v-model="search", autocomplete="off", autofocus)
     
     md-card
         md-card-content

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -77,9 +77,12 @@ export default {
                 }
                 if (matches) {
                     filteredMembers.push(mem);
+                    // limit number of results to reduce render time
+                    if (filteredMembers.length == 10) {
+                        break;
+                    }
                 }
             }
-            filteredMembers = filteredMembers.slice(0,10); // only show first 10 to minimise rendering times
             return filteredMembers;
         },
     }

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -43,8 +43,8 @@ export default {
                 let matches = true;
                 for (let word of query) {
                     let wordMatches = false;
-                    for (let field of ["firstName", "lastName"]) {
-                        if (mem[field] && mem[field].toLowerCase().includes(word)) {
+                    for (let field of ["firstName", "lastName", "access", "sid"]) {
+                        if (mem[field] && String(mem[field]).toLowerCase().includes(word)) {
                             wordMatches = true;
                             break;
                         }

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -52,6 +52,9 @@ export default {
                 } else if (/^09\d{9}\d{2}\d{2}$/.test(query)) {
                     // SID library barcode: 09<SID><YY><CHK>
                     query = query.slice(2, 9+2);
+                } else if (query.length > 9) {
+                    // probably the start of a barcode, short circuit and wait for the full thing
+                    return [];
                 }
                 query = [query];
             } else {

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -1,8 +1,9 @@
 <template lang="pug">
 div
-    md-field.search-box
-        label Search
-        md-input(v-model="search")
+    form(@submit.prevent="autoselect")
+        md-field.search-box
+            label Search
+            md-input(v-model="search", autofocus)
     
     md-card
         md-card-content
@@ -32,7 +33,12 @@ export default {
     methods: {
         attended(id, field) {
             return this.shared.attendance.find(a => a.member == id && a.event == this.$route.params.id)
-        }
+        },
+        autoselect() {
+            if (this.filteredMembers.length == 1) {
+                this.shared.selectedMember = this.filteredMembers[0].id;
+            }
+        },
     },
     computed: {
         filteredMembers() {

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -46,7 +46,7 @@ export default {
             // is the search text numeric?
             if (/^\d+$/.test(query)) {
                 // yup. let's check if it's a barcode
-                if (/^9[12]0000\d{7}$/.test(query)) {
+                if (/^9[012]0000\d{7}$/.test(query)) {
                     // ACCESS card/app barcodes
                     query = String(+query.slice(-7));
                 } else if (/^09\d{9}\d{2}\d{2}$/.test(query)) {

--- a/src/components/EventAttendance.vue
+++ b/src/components/EventAttendance.vue
@@ -35,8 +35,23 @@ export default {
         }
     },
     computed: {
-         filteredMembers () {
-            let query = this.search.toLowerCase().split(/\s+/g);
+        filteredMembers() {
+            let query = this.search;
+            // is the search text numeric?
+            if (/^\d+$/.test(query)) {
+                // yup. let's check if it's a barcode
+                if (/^92(?:00|1[1-3])00\d{7}$/.test(query)) {
+                    // ACCESS card/app barcodes
+                    query = query.slice(-7);
+                } else if (/^09\d{9}\d{2}\d{2}$/.test(query)) {
+                    // SID library barcode: 09<SID><YY><CHK>
+                    query = query.slice(2, 9+2);
+                }
+                query = [query];
+            } else {
+                query = query.toLowerCase().split(/\s+/g);
+            }
+
             let filteredMembers = [];
             for (let id in this.shared.members) {
                 let mem = this.shared.members[id];


### PR DESCRIPTION
This builds on top of #11.

* Allow searching by ACCESS and SID, and allow scanning the barcodes.
* Make pressing enter select the only matching member, if there's only
  one. This makes using a barcode scanner even easier.
* Make searching slightly more efficient.

Fixes: #6